### PR TITLE
chore: changing name of the task

### DIFF
--- a/openshift/iib-template.yaml
+++ b/openshift/iib-template.yaml
@@ -86,11 +86,9 @@ objects:
           description: FBC Image to be added to index image
         - name: iibServiceConfigSecret
           type: string
-          default: "iib-production-services-config"
           description: Secret with IIB service config to be used
         - name: iibServiceAccountSecret
           type: string
-          default: "iib-service-account"
           description: Secret with IIB credentials to be used
         - name: fbcFragment
           type: string

--- a/openshift/iib-template.yaml
+++ b/openshift/iib-template.yaml
@@ -123,12 +123,12 @@ objects:
             - name: IIB_SERVICE_URL
               valueFrom:
                 secretKeyRef:
-                  name: iib-production-services-config
+                  name: $(params.iibServiceConfigSecret)
                   key: url
             - name: IIB_OVERWRITE_FROM_INDEX_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: iib-production-services-config
+                  name: $(params.iibServiceConfigSecret)
                   key: overwriteFromIndexToken
           script: |
             #!/usr/bin/env bash

--- a/openshift/iib-template.yaml
+++ b/openshift/iib-template.yaml
@@ -46,9 +46,9 @@ objects:
       workspaces:
         - name: release-workspace
       tasks:
-        - name: add-fbc-fragment-to-index-image
+        - name: task-add-fbc-fragment-to-index-image
           taskRef:
-            name: add-fbc-fragment-to-index-image
+            name: task-add-fbc-fragment-to-index-image
           params:
             - name: binaryImage
               value: $(params.binaryImage)
@@ -71,7 +71,7 @@ objects:
   - apiVersion: tekton.dev/v1beta1
     kind: Task
     metadata:
-      name: add-fbc-fragment-to-index-image
+      name: task-add-fbc-fragment-to-index-image
       labels:
         app.kubernetes.io/version: "0.1"
       annotations:


### PR DESCRIPTION
- renames the task due to some cache making it fail even if the
  task definition changed.
